### PR TITLE
Fetch stream URLs for playback, closes #78

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -42,6 +42,7 @@ export interface TrackResource {
 
 export type GetTrackOptions = {
   track_id: string,
+  /** Only for the V1 API. */
   secret_token?: string,
 };
 
@@ -184,5 +185,17 @@ export class SoundCloudV2Client implements SoundCloudClient {
 
   getTracks(options: GetTracksOptions): Promise<TrackResource[]> {
     return this.#get('/tracks', { ids: options.ids });
+  }
+
+  async getStreamUrl(track: TrackResource): Promise<string | null> {
+    const format = track.media?.transcodings.find((media) => media.format.protocol === 'progressive');
+    if (!format) {
+      return null;
+    }
+
+    const { url } = await this.#get<{ url: string }>(format.url, {
+      track_authorization: track.track_authorization,
+    });
+    return url;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export default function soundCloudSource(_: unknown, opts: SoundCloudOptions) {
 
   async function resolve(url: string) {
     const body = await client.resolveTrack({ url });
-    return normalizeMedia(body);
+    return body ? normalizeMedia(body) : null;
   }
 
   function sortSourceIDsAndURLs(list: string[]): { urls: string[], sourceIDs: string[] } {
@@ -93,19 +93,23 @@ export default function soundCloudSource(_: unknown, opts: SoundCloudOptions) {
     const items: Record<string, UwMedia> = {};
     urls.forEach((url, index) => {
       const item = urlItems[index];
-      items[url] = item;
+      if (item) {
+        items[url] = item;
+      }
     });
     sourceIDItems.forEach((sound) => {
       const item = normalizeMedia(sound);
       items[item.sourceID] = item;
     });
-    return sourceIDsAndURLs.map((input) => items[input]);
+    return sourceIDsAndURLs
+      .map((input) => items[input])
+      .filter((item) => item != null);
   }
 
   async function search(query: string, offset = 0): Promise<UwMedia[]> {
     if (/^https?:\/\/(api\.)?soundcloud\.com\//.test(query)) {
       const track = await resolve(query);
-      return [track];
+      return track ? [track] : [];
     }
 
     const results = await client.search({

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,7 @@ const WEB_HOST = 'https://soundcloud.com';
 const API_V1_HOST = 'https://api.soundcloud.com';
 const API_V2_HOST = 'https://api-v2.soundcloud.com';
 
+const CONTEXT = {};
 const fixture = (name) => path.join(__dirname, 'responses', `${name}.json`);
 
 describe('v1', () => {
@@ -31,7 +32,7 @@ describe('v1', () => {
       })
       .replyWithFile(200, fixture('search'));
 
-    const results = await src.search('oceanfromtheblue');
+    const results = await src.search(CONTEXT, 'oceanfromtheblue');
 
     // Limit is 50 but the results fixture only contains 10 :)
     assert.equal(results.length, 10);
@@ -55,7 +56,7 @@ describe('v1', () => {
         JSON.parse(fs.readFileSync(fixture('track.346713308'), 'utf8')),
       ]);
 
-    const items = await src.get(['389870604', '346713308']);
+    const items = await src.get(CONTEXT, ['389870604', '346713308']);
 
     assert.equal(items.length, 2);
 
@@ -75,7 +76,7 @@ describe('v1', () => {
         return JSON.parse(fs.readFileSync(fixture('401'), 'utf8'));
       });
 
-    await assert.rejects(() => src.get(['389870604', '346713308']), /A request must contain the Authorization header/);
+    await assert.rejects(() => src.get(CONTEXT, ['389870604', '346713308']), /A request must contain the Authorization header/);
   });
 });
 
@@ -94,7 +95,7 @@ describe('v2', () => {
       .replyWithFile(200, fixture('search2'));
 
     const src = createSourceV2();
-    const results = await src.search('oceanfromtheblue');
+    const results = await src.search(CONTEXT, 'oceanfromtheblue');
 
     // Limit is 50 but the results fixture only contains 20 :)
     assert.equal(results.length, 20);


### PR DESCRIPTION
This requires support in üWave Core. It looks up an mp3 URL for the track and returns that as `sourceData`.

https://github.com/u-wave/core/pull/481