### PR TITLE
build: switch to tsdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Renée Kooi <renee@kooi.me>"
   ],
   "exports": {
-    ".": "./dist/index.js",
+    ".": "./dist/index.mjs",
     "./package.json": "./package.json"
   },
   "type": "module",
@@ -30,12 +30,12 @@
     "nock": "^14.0.0",
     "oxlint": "^1.1.0",
     "pino": "^10.0.0",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.21.7",
     "typescript": "^5.0.2",
     "vitest": "^4.0.3"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsdown src/index.ts --format esm --dts",
     "prepare": "npm run build",
     "lint": "oxlint src && dprint check",
     "tests-only": "vitest run",


### PR DESCRIPTION
I think this will improve compatibility with TS6?
Also more in line with new vite versions used in all üWave projects
